### PR TITLE
fix: Fallback link pointing to github during dw2pdf rendering

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    bpmnio
 author  Jaap de Haan
 email   jaap.dehaan@color-of-code.de
-date    2022-07-24
+date    2022-07-25
 name    bpmnio
 desc    Renders BPMN or DMN xml using the bpmn.io js library
 url     http://www.dokuwiki.org/plugin:bpmnio

--- a/syntax/bpmnio.php
+++ b/syntax/bpmnio.php
@@ -50,8 +50,20 @@ class syntax_plugin_bpmnio_bpmnio extends DokuWiki_Syntax_Plugin
 
     public function render($mode, Doku_Renderer $renderer, $data)
     {
+        list($match, $state) = $data;
+
+        if (is_a($renderer, 'renderer_plugin_dw2pdf')) {
+            if ($state == DOKU_LEXER_EXIT) {
+                $renderer->doc .= <<<HTML
+                    <div class="plugin-bpmnio">
+                        <a href="https://github.com/Color-Of-Code/dokuwiki-plugin-bpmnio/issues/4">DW2PDF support missing: Help wanted</a>
+                    </div>
+                    HTML;
+            }
+            return true;
+        }
+
         if ($mode == 'xhtml' || $mode == 'odt') {
-            list($match, $state) = $data;
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                     preg_match('/<bpmnio type="(\w+)">/', $match, $type);


### PR DESCRIPTION
* Ref #4
* hint to the github issue left to implement, instead of cryptic base64 code.