### PR TITLE
fix: Add action.php & syntax.php are deleted files

### DIFF
--- a/deleted.files
+++ b/deleted.files
@@ -1,2 +1,4 @@
+action.php
 style.css
 style.less
+syntax.php


### PR DESCRIPTION
These were forgotten to get added in the to be deleted files resulting in plugin problems for users coming from an older version.