### PR TITLE
fix: remove broken dmn edit capability

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    bpmnio
 author  Jaap de Haan
 email   jaap.dehaan@color-of-code.de
-date    2023-03-30
+date    2023-04-16
 name    bpmnio
 desc    Renders BPMN or DMN xml using the bpmn.io js library
 url     http://www.dokuwiki.org/plugin:bpmnio

--- a/script.js
+++ b/script.js
@@ -2,6 +2,5 @@
 /* DOKUWIKI:include_once vendor/bpmn-js/dist/bpmn-modeler.production.min.js */
 
 /* DOKUWIKI:include_once vendor/dmn-js/dist/dmn-viewer.production.min.js */
-/* DOKUWIKI:include_once vendor/dmn-js/dist/dmn-modeler.production.min.js */
 
 /* DOKUWIKI:include_once script/bpmnio_render.js */


### PR DESCRIPTION
The viewer display is repaired at the cost of the lost editor for DMN (anyways the feedback of the modified XML did not work and needs a proper fix)